### PR TITLE
Fix get-root reference

### DIFF
--- a/lsp-javascript-typescript.el
+++ b/lsp-javascript-typescript.el
@@ -34,7 +34,7 @@
 							   (directory-files dir nil "package.json"))))
 
 (lsp-define-stdio-client lsp-javascript-typescript "javascript"
-			 #'lsp-javascript--get-root '("javascript-typescript-stdio"))
+			 lsp-javascript--get-root '("javascript-typescript-stdio"))
 
 (provide 'lsp-javascript-typescript)
 ;;; lsp-javascript-typescript.el ends here


### PR DESCRIPTION
This is not a function call, but actually a function definition therefore the
`#'`. Can't be used.

This seems to solve the problem for me, without this it complains about `lsp-javascript--get-root` not being a function.