### PR TITLE
ignore missing files

### DIFF
--- a/lsp-javascript-typescript.el
+++ b/lsp-javascript-typescript.el
@@ -34,7 +34,8 @@
 							   (directory-files dir nil "package.json"))))
 
 (lsp-define-stdio-client lsp-javascript-typescript "javascript"
-			 lsp-javascript--get-root '("javascript-typescript-stdio"))
+                         lsp-javascript--get-root '("javascript-typescript-stdio")
+                         :ignore-regexps '("readFile .*? requested by TypeScript but content not available"))
 
 (provide 'lsp-javascript-typescript)
 ;;; lsp-javascript-typescript.el ends here


### PR DESCRIPTION
If a file is missing from either your package.json or one of your dependencies' package.json then the minibuffer shows a message like "readfile <some file> requested by Typescript but content not available" in place of the completion, doc, etc.  This PR ignores that message.