### PR TITLE
Ignore Nuclide INFO-level messages in Flow

### DIFF
--- a/lsp-javascript-flow.el
+++ b/lsp-javascript-flow.el
@@ -37,7 +37,8 @@
 
 (lsp-define-stdio-client
  lsp-javascript-flow "javascript"
- lsp-javascript--get-root '("flow-language-server" "--stdio"))
+ lsp-javascript--get-root '("flow-language-server" "--stdio")
+ :ignore-messages '("\[INFO].*?nuclide"))
 
 (provide 'lsp-javascript-flow)
 ;;; lsp-javascript-flow.el ends here


### PR DESCRIPTION
- Adds `:ignore-messages` regex for INFO nuclide messages
- Retains other INFO messages (notably, useful `flow-versions` output)
- Resolves emacs-lsp/lsp-javascript#7

Please let me know if any corrections need to be made. Thank you!