### PR TITLE
Fixed a typo from refactoring.

### DIFF
--- a/lsp-javascript-typescript.el
+++ b/lsp-javascript-typescript.el
@@ -50,7 +50,7 @@
    client "javascript" 'lsp-javascript-typescript--render-string))
 
 (lsp-define-stdio-client lsp-javascript-typescript "javascript"
-                         lsp-javascript--get-root '("javascript-typescript-stdio")
+                         lsp-javascript-typescript--get-root '("javascript-typescript-stdio")
                          :ignore-messages '("readFile .*? requested by TypeScript but content not available")
                          :initialize 'lsp-javascript-typescript--initialize-client)
 


### PR DESCRIPTION
Fixed a typo that was created during refactoring in 9c843a56aa18a2ab15768eae79e6e137240f31b3.